### PR TITLE
Fix variable collision and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Discord Bot Token
+BOT_TOKEN=your_bot_token_here
+
+# Discord Application (Client) ID
+CLIENT_ID=your_client_id_here
+
+# Optional Guild ID for guild-specific commands
+GUILD_ID=your_guild_id_here
+
+# MongoDB connection URI
+DATABASE_URI=mongodb://localhost:27017/synergy-bot
+
+# Channels and webhooks
+LOG_CHANNEL_ID=log_channel_id_here
+LOG_WEBHOOK_URL=log_webhook_url_here
+ANNOUNCEMENT_CHANNEL_ID=announcement_channel_id_here
+NOTIFICATION_CHANNEL_ID=notification_channel_id_here
+WEBHOOK_URL=export_webhook_url_here
+
+# Cache settings
+CACHE_TTL=300
+CACHE_CHECK_PERIOD=60
+
+# Roles
+ADMIN_ROLE_ID=admin_role_id_here

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -37,11 +37,17 @@
 4. Создайте файл `.env` в корневой папке проекта со следующим содержимым:
    ```
    BOT_TOKEN=ваш_токен_бота
-   MONGODB_URI=ваша_строка_подключения_к_mongodb
+   DATABASE_URI=ваша_строка_подключения_к_mongodb
    CLIENT_ID=id_вашего_приложения_discord
    GUILD_ID=id_вашего_сервера_discord
    ADMIN_ROLE_ID=id_роли_администратора
    LOG_CHANNEL_ID=id_канала_для_логов
+   LOG_WEBHOOK_URL=url_вебхука_для_логов
+   ANNOUNCEMENT_CHANNEL_ID=id_канала_объявлений
+   NOTIFICATION_CHANNEL_ID=id_канала_уведомлений
+   WEBHOOK_URL=url_вебхука_для_экспорта
+   CACHE_TTL=300
+   CACHE_CHECK_PERIOD=60
    ```
    Замените значения на ваши собственные.
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,17 @@
 4. Создайте файл `.env` в корневой папке проекта со следующим содержимым:
    ```
    BOT_TOKEN=ваш_токен_бота
-   MONGODB_URI=ваша_строка_подключения_к_mongodb
+   DATABASE_URI=ваша_строка_подключения_к_mongodb
    CLIENT_ID=id_вашего_приложения_discord
    GUILD_ID=id_вашего_сервера_discord
    ADMIN_ROLE_ID=id_роли_администратора
    LOG_CHANNEL_ID=id_канала_для_логов
+   LOG_WEBHOOK_URL=url_вебхука_для_логов
+   ANNOUNCEMENT_CHANNEL_ID=id_канала_объявлений
+   NOTIFICATION_CHANNEL_ID=id_канала_уведомлений
+   WEBHOOK_URL=url_вебхука_для_экспорта
+   CACHE_TTL=300
+   CACHE_CHECK_PERIOD=60
    ```
    Замените значения на ваши собственные.
 

--- a/project-structure.md
+++ b/project-structure.md
@@ -107,10 +107,16 @@ CLIENT_ID=your_client_id_here
 GUILD_ID=your_guild_id_here
 
 # URI подключения к MongoDB
-MONGODB_URI=mongodb://localhost:27017/synergy_bot
+DATABASE_URI=mongodb://localhost:27017/synergy_bot
 
 # ID канала для логов
 LOG_CHANNEL_ID=your_log_channel_id_here
+LOG_WEBHOOK_URL=your_log_webhook_url_here
+ANNOUNCEMENT_CHANNEL_ID=your_announcement_channel_id_here
+NOTIFICATION_CHANNEL_ID=your_notification_channel_id_here
+WEBHOOK_URL=your_export_webhook_url_here
+CACHE_TTL=300
+CACHE_CHECK_PERIOD=60
 
 # ID ролей
 ADMIN_ROLE_ID=your_admin_role_id_here

--- a/src/utils/recurringEventManager.js
+++ b/src/utils/recurringEventManager.js
@@ -77,14 +77,14 @@ class RecurringEventManager {
      * @returns {Object|null} Даты следующего мероприятия или null, если больше нет повторений
      */
     static calculateNextEventDates(lastStartDate, lastEndDate, recurringSettings) {
-        const { frequency, interval, endAfterOccurrences, endDate } = recurringSettings;
+        const { frequency, interval, endAfterOccurrences, endDate: recurringEndDate } = recurringSettings;
         
         // Преобразуем строковые даты в объекты Date, если необходимо
         const startDate = new Date(lastStartDate);
-        const endDate = new Date(lastEndDate);
+        const lastEndDateObj = new Date(lastEndDate);
         
         // Вычисляем продолжительность мероприятия в миллисекундах
-        const duration = endDate.getTime() - startDate.getTime();
+        const duration = lastEndDateObj.getTime() - startDate.getTime();
         
         // Вычисляем дату начала следующего мероприятия
         let nextStartDate = new Date(startDate);
@@ -113,7 +113,7 @@ class RecurringEventManager {
         }
         
         // Проверяем, не превышена ли конечная дата повторений
-        if (recurringSettings.endDate && nextStartDate > new Date(recurringSettings.endDate)) {
+        if (recurringEndDate && nextStartDate > new Date(recurringEndDate)) {
             return null;
         }
         


### PR DESCRIPTION
## Summary
- avoid variable name collision in `recurringEventManager`
- document all environment variables and use `DATABASE_URI` consistently
- provide `.env.example` sample configuration

## Testing
- `node --check src/utils/recurringEventManager.js`
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684895d98f08832daa6f31db47a7651a